### PR TITLE
fix replace in line 15

### DIFF
--- a/vagrant_setup.py
+++ b/vagrant_setup.py
@@ -12,7 +12,7 @@ def find_line_items(identifier, input_string):
 
 def get_usb_devices():
     usb_string = subprocess.check_output(['VBoxManage', 'list', 'usbhost'])
-    usb_string = usb_string.decode("utf-8").replace('r', '')
+    usb_string = usb_string.decode("utf-8").replace('\r', '')
 
     usb_devices = usb_string.split("\n\n")
     devices = []


### PR DESCRIPTION
replace on line 15 is setup incorrectly. It's currently setup as:
usb_string = usb_string.decode("utf-8").replace("r","")

when it should be:
usb_string = usb_string.decode("utf-8").replace("\r","")

the function never finds any of the product ids/etc. since "Product" would end up as "Poduct" and so on.