### PR TITLE
Allow #comment lines in macros. Updated the Macros documentation.

### DIFF
--- a/docs/Macros.md
+++ b/docs/Macros.md
@@ -43,6 +43,30 @@ L_STICK@+000+000 0.75s
 1.0s
 ```
 
+### Loops
+
+A simple for-loop can be used to repeat a macro block a specified number of times. The below example loops through an indented macro block 100 times.
+
+```
+LOOP 100
+    B 0.1s
+    0.1s
+```
+
+Nested loops are also supported.
+
+```
+LOOP 100
+    B 0.1s
+    0.1s
+    # Nested loop
+    LOOP 5
+        A 0.1s
+        0.1s
+```
+
+Note, a macro line starting with `#` is ignored.
+
 ## Macro Control Values
 
 | Macro Value | Control Name |

--- a/nxbt/controller/input.py
+++ b/nxbt/controller/input.py
@@ -307,6 +307,7 @@ class InputParser():
 
         parsed = macro.split("\n")
         parsed = list(filter(lambda s: not s.strip() == "", parsed))
+        parsed = list(filter(lambda s: not s.strip().startswith("#"), parsed))
         parsed = self.parse_loops(parsed)
 
         return parsed


### PR DESCRIPTION
Comments would be rather handy when some complex macros exceed 500 lines.
Also updated the Macros doc with LOOP.