### PR TITLE
Update dependencies

### DIFF
--- a/nxbt/bluez.py
+++ b/nxbt/bluez.py
@@ -110,11 +110,13 @@ def toggle_clean_bluez(toggle):
     """
 
     service_path = "/lib/systemd/system/bluetooth.service"
-    override_dir = Path("/run/systemd/system/bluetooth.service.d")
-    override_path = override_dir / "nxbt.conf"
+    runtime_override_dir = Path("/run/systemd/system/bluetooth.service.d")
+    permanent_override_dir = Path("/etc/systemd/system/bluetooth.service.d")
+    runtime_override_path = runtime_override_dir / "nxbt.conf"
+    permanent_override_path = permanent_override_dir / "nxbt.conf"
 
     if toggle:
-        if override_path.is_file():
+        if runtime_override_path.is_file() or permanent_override_path.is_file():
             # Override exist, no need to restart bluetooth
             return
 
@@ -128,12 +130,12 @@ def toggle_clean_bluez(toggle):
 
         override = f"[Service]\nExecStart=\n{exec_start}"
 
-        override_dir.mkdir(parents=True, exist_ok=True)
-        with override_path.open("w") as f:
+        runtime_override_dir.mkdir(parents=True, exist_ok=True)
+        with runtime_override_path.open("w") as f:
             f.write(override)
     else:
         try:
-            os.remove(override_path)
+            os.remove(runtime_override_path)
         except FileNotFoundError:
             # Override doesn't exist, no need to restart bluetooth
             return

--- a/nxbt/nxbt.py
+++ b/nxbt/nxbt.py
@@ -227,7 +227,7 @@ class Nxbt():
         cm = _ControllerManager(state, self._bluetooth_lock)
         # Ensure a SystemExit exception is raised on SIGTERM
         # so that we can gracefully shutdown.
-        signal.signal(signal.SIGTERM, lambda sigterm_handler: sys.exit(0))
+        signal.signal(signal.SIGTERM, lambda *_: sys.exit(0))
 
         try:
             while True:

--- a/setup.py
+++ b/setup.py
@@ -6,9 +6,9 @@ setup(
     long_description_content_type="text/markdown",
     install_requires=[
         "dbus-python==1.2.16",
-        "Flask==1.1.2",
-        "Flask-SocketIO==5.0.1",
-        "eventlet==0.31.0",
+        "Flask~=2.0.0",
+        "Flask-SocketIO~=5.1.0",
+        "eventlet~=0.33.0",
         "blessed==1.17.10",
         "pynput==1.7.1",
         "psutil==5.6.6",


### PR DESCRIPTION
Updating Flask dependency. Should fix #61 

Tested with raspberry pi 1 and python 3.9.2.
Tested the app locally on archlinux with python 3.10.2 (couldn't pair though, but I haven't run it with sudo on this device, only disabled the plugins)

Chores:
 - Changed the sigterm handler to not crash...
 - also check permanent bluetooth/bluez override
