### PR TITLE
Use busy wait for main server loop

### DIFF
--- a/nxbt/cli.py
+++ b/nxbt/cli.py
@@ -275,12 +275,13 @@ def macro():
     reconnect_target = get_reconnect_target()
 
     nx = Nxbt(debug=args.debug, log_to_file=args.logfile)
-    print("Creating controller...")
+    print("Creating controller (frequency = 132)...")
     index = nx.create_controller(
         PRO_CONTROLLER,
         colour_body=random_colour(),
         colour_buttons=random_colour(),
-        reconnect_address=reconnect_target)
+        reconnect_address=reconnect_target,
+        frequency=132)
     print("Waiting for connection...")
     nx.wait_for_connection(index)
     print("Connected!")

--- a/nxbt/cli.py
+++ b/nxbt/cli.py
@@ -275,7 +275,7 @@ def macro():
     reconnect_target = get_reconnect_target()
 
     nx = Nxbt(debug=args.debug, log_to_file=args.logfile)
-    print("Creating controller (frequency = 132)...")
+    print("Creating controller...")
     index = nx.create_controller(
         PRO_CONTROLLER,
         colour_body=random_colour(),

--- a/nxbt/controller/server.py
+++ b/nxbt/controller/server.py
@@ -120,12 +120,13 @@ class ControllerServer():
 
     def mainloop(self, itr, ctrl):
 
-        duration_start = time.perf_counter()
+        duration_start = time.perf_counter_ns()
         period = 1 / self.frequency
-        t = time.perf_counter()
+        period_ns = int(period * 1_000_000_000)
+        t = time.perf_counter_ns()
         while True:
             # Start timing command processing
-            timer_start = time.perf_counter()
+            timer_start = time.perf_counter_ns()
 
             # Attempt to get output from Switch
             try:
@@ -183,12 +184,15 @@ class ControllerServer():
                 itr, ctrl = self.save_connection(e)
 
             # Figure out how long it took to process commands
-            duration_end = time.perf_counter()
+            duration_end = time.perf_counter_ns()
             duration_elapsed = duration_end - duration_start
             duration_start = duration_end
             
-            t += period
-            time.sleep(max(0,t-time.perf_counter()))
+            t += period_ns
+            #time.sleep(max(0,t-time.perf_counter()))
+            while True:
+                if time.perf_counter_ns() > t:
+                    break
 
             self.tick += 1
 


### PR DESCRIPTION
Tries to fix #47 (Macro inputs getting skipped)

For [my use case](https://github.com/JonathanNye/img2splat) of putting images into Splatoon posts, I'm generating macros with many thousands of inputs. Like some others reported, I was running into consistency issues and missed macro inputs, even early into the script execution.

I wondered if the [accuracy of sleep()](https://stackoverflow.com/questions/1133857/how-accurate-is-pythons-time-sleep) was contributing, so this change modifies the main server loop to use `perf_counter_ns()` and busy waits for timing instead of `sleep()`.

Although I can only speak anecdotally, this seemed to greatly improve the consistency of macros inputs. And perhaps other timing-critical parts of NXBT could benefit from busy waits as well?

Other context: I was running this on a Windows 10 host machine with Vagrant.

Even if this change isn't valuable to you, thank you for your work! I had fun writing some goofy tooling on top of NXBT 😀 