### PR TITLE
Correct plus and minus input index

### DIFF
--- a/nxbt/controller/input.py
+++ b/nxbt/controller/input.py
@@ -250,9 +250,9 @@ class InputParser():
 
         # Shared byte
         if controller_input["MINUS"]:
-            shared[7] = '1'
-        if controller_input["PLUS"]:
             shared[6] = '1'
+        if controller_input["PLUS"]:
+            shared[7] = '1'
         if controller_input["R_STICK"]["PRESSED"]:
             shared[5] = '1'
         if controller_input["L_STICK"]["PRESSED"]:


### PR DESCRIPTION
Have checked using games that have different actions for plus and minus buttons (e.g. Pokémon Scarlet and Pokémon Violet), the original values of the input index will trigger opposite action.